### PR TITLE
Improve log directory initialization and propagation

### DIFF
--- a/debug-api.php
+++ b/debug-api.php
@@ -2,8 +2,11 @@
 header('Content-Type: application/json');
 header('Access-Control-Allow-Origin: *');
 
-$logDir = 'logs/';
-$logFiles = glob($logDir . '*.log');
+require_once 'simple-logger.php';
+
+$logDir = SimpleLogger::getLogDir();
+$logFiles = is_dir($logDir) ? glob($logDir . '*.log') : [];
+$logFiles = $logFiles ?: [];
 
 $response = [
     'success' => true,

--- a/log-viewer.php
+++ b/log-viewer.php
@@ -7,7 +7,7 @@
 require_once 'simple-logger.php';
 
 // Configurações
-$logDir = 'logs/';
+$logDir = SimpleLogger::getLogDir();
 $maxLines = 1000; // Máximo de linhas a exibir
 $defaultFilter = $_GET['filter'] ?? 'all';
 $defaultDate = $_GET['date'] ?? date('Y-m-d');
@@ -45,7 +45,7 @@ function readLogs($date, $filter = 'all', $maxLines = 1000) {
 // Função para obter datas disponíveis
 function getAvailableDates() {
     global $logDir;
-    $files = glob($logDir . 'app_*.log');
+    $files = glob($logDir . 'app_*.log') ?: [];
     $dates = [];
     
     foreach ($files as $file) {

--- a/monitor-webhook.php
+++ b/monitor-webhook.php
@@ -1,12 +1,14 @@
 <?php
 /**
  * Monitor de Webhook PIX Oasy.fy
- * 
+ *
  * Script para monitorar logs, estatísticas e status do webhook
  */
 
 // Configurações
-$logDir = 'logs/';
+require_once 'simple-logger.php';
+
+$logDir = SimpleLogger::getLogDir();
 $dataDir = 'data/';
 $refreshInterval = 5; // segundos
 

--- a/simple-logger.php
+++ b/simple-logger.php
@@ -5,21 +5,46 @@
  */
 
 class SimpleLogger {
-    private static $logDir = 'logs/';
+    private static $defaultLogDir = 'logs/';
+    private static $logDir = '';
     private static $logFile = '';
     private static $requestId = '';
-    
+
     public static function init() {
-        // Criar diretório de logs se não existir
-        if (!file_exists(self::$logDir)) {
-            mkdir(self::$logDir, 0755, true);
+        if (!empty(self::$logFile) && !empty(self::$logDir)) {
+            return true;
         }
-        
+
+        $candidates = self::getCandidateDirectories();
+
+        foreach ($candidates as $candidate) {
+            $normalizedDir = self::normalizeLogDir($candidate);
+
+            if (self::ensureLogDirectory($normalizedDir)) {
+                self::$logDir = $normalizedDir;
+                break;
+            }
+        }
+
+        if (empty(self::$logDir)) {
+            $fallbackDir = self::normalizeLogDir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'matheus-logs');
+
+            if (self::ensureLogDirectory($fallbackDir)) {
+                self::reportInitIssue('Usando diretório alternativo para logs: ' . $fallbackDir);
+                self::$logDir = $fallbackDir;
+            } else {
+                self::reportInitIssue('Falha ao criar diretório de fallback para logs: ' . $fallbackDir);
+                return false;
+            }
+        }
+
         // Gerar ID único para a requisição
         self::$requestId = uniqid('req_', true);
-        
+
         // Definir arquivo de log do dia
         self::$logFile = self::$logDir . 'app_' . date('Y-m-d') . '.log';
+
+        return true;
     }
     
     /**
@@ -93,22 +118,22 @@ class SimpleLogger {
      * Método principal de log
      */
     private static function log($level, $message, $data = []) {
-        if (empty(self::$requestId)) {
-            self::init();
-        }
-        
-        $timestamp = date('Y-m-d H:i:s');
-        $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
-        
-        // Formatar dados extras se existirem
         $extraData = '';
         if (!empty($data)) {
             $extraData = ' | ' . json_encode($data, JSON_UNESCAPED_UNICODE);
         }
-        
+
+        if (!self::init()) {
+            error_log('SIMPLE_LOGGER: Falha ao inicializar diretório de logs. [' . $level . '] ' . $message . $extraData);
+            return;
+        }
+
+        $timestamp = date('Y-m-d H:i:s');
+        $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+
         // Linha de log formatada (sem interpolação incorreta)
         $logLine = '[' . $timestamp . '] [' . $level . '] [' . $ip . '] [' . self::$requestId . '] ' . $message . $extraData . "\n";
-        
+
         // Escrever no arquivo
         file_put_contents(self::$logFile, $logLine, FILE_APPEND | LOCK_EX);
         
@@ -122,9 +147,13 @@ class SimpleLogger {
      * Limpar logs antigos (manter apenas últimos 7 dias)
      */
     public static function cleanup() {
-        $files = glob(self::$logDir . 'app_*.log');
+        if (!self::init()) {
+            return;
+        }
+
+        $files = glob(self::$logDir . 'app_*.log') ?: [];
         $cutoff = time() - (7 * 24 * 3600); // 7 dias atrás
-        
+
         foreach ($files as $file) {
             if (filemtime($file) < $cutoff) {
                 unlink($file);
@@ -132,24 +161,45 @@ class SimpleLogger {
             }
         }
     }
-    
+
     /**
      * Obter estatísticas dos logs
      */
     public static function getStats() {
-        $files = glob(self::$logDir . 'app_*.log');
+        $logDir = self::getLogDir();
+
+        if (!is_dir($logDir)) {
+            return [
+                'total_files' => 0,
+                'total_size' => self::formatBytes(0),
+                'log_directory' => $logDir
+            ];
+        }
+
+        $files = glob($logDir . 'app_*.log') ?: [];
         $totalFiles = count($files);
         $totalSize = 0;
-        
+
         foreach ($files as $file) {
             $totalSize += filesize($file);
         }
-        
+
         return [
             'total_files' => $totalFiles,
             'total_size' => self::formatBytes($totalSize),
-            'log_directory' => self::$logDir
+            'log_directory' => $logDir
         ];
+    }
+
+    /**
+     * Retorna o diretório atual de logs (já normalizado)
+     */
+    public static function getLogDir() {
+        if (self::init()) {
+            return self::$logDir;
+        }
+
+        return self::normalizeLogDir(self::$defaultLogDir);
     }
     
     /**
@@ -157,12 +207,96 @@ class SimpleLogger {
      */
     private static function formatBytes($bytes, $precision = 2) {
         $units = array('B', 'KB', 'MB', 'GB', 'TB');
-        
+
         for ($i = 0; $bytes > 1024 && $i < count($units) - 1; $i++) {
             $bytes /= 1024;
         }
-        
+
         return round($bytes, $precision) . ' ' . $units[$i];
+    }
+
+    /**
+     * Gera lista de diretórios candidatos a serem utilizados para logs
+     */
+    private static function getCandidateDirectories() {
+        $candidates = [];
+
+        $envSimpleLoggerDir = getenv('SIMPLE_LOGGER_DIR');
+        if ($envSimpleLoggerDir !== false && $envSimpleLoggerDir !== '') {
+            $candidates[] = $envSimpleLoggerDir;
+        }
+
+        $envOasyfyLogDir = getenv('OASYFY_LOG_DIR');
+        if ($envOasyfyLogDir !== false && $envOasyfyLogDir !== '') {
+            $candidates[] = $envOasyfyLogDir;
+        }
+
+        if (defined('OASYFY_LOG_CONFIG')) {
+            $logConfig = OASYFY_LOG_CONFIG;
+            if (is_array($logConfig) && !empty($logConfig['log_dir'])) {
+                $candidates[] = $logConfig['log_dir'];
+            }
+        }
+
+        $candidates[] = self::$defaultLogDir;
+
+        $candidates = array_filter($candidates, function ($dir) {
+            return is_string($dir) && trim($dir) !== '';
+        });
+
+        return array_values(array_unique($candidates));
+    }
+
+    /**
+     * Normaliza o caminho garantindo separador final
+     */
+    private static function normalizeLogDir($dir) {
+        if (!is_string($dir) || $dir === '') {
+            return '';
+        }
+
+        $normalized = rtrim($dir, "/\\");
+
+        if ($normalized === '') {
+            return DIRECTORY_SEPARATOR;
+        }
+
+        return $normalized . DIRECTORY_SEPARATOR;
+    }
+
+    /**
+     * Garante que o diretório existe e é gravável
+     */
+    private static function ensureLogDirectory($dir) {
+        if ($dir === '') {
+            return false;
+        }
+
+        if (!is_dir($dir)) {
+            if (file_exists($dir) && !is_dir($dir)) {
+                self::reportInitIssue('Caminho de logs existe, porém não é diretório: ' . $dir);
+                return false;
+            }
+
+            if (!@mkdir($dir, 0755, true)) {
+                self::reportInitIssue('Não foi possível criar diretório de logs: ' . $dir);
+                return false;
+            }
+        }
+
+        if (!is_writable($dir)) {
+            self::reportInitIssue('Diretório de logs não é gravável: ' . $dir);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Registra mensagens de falha na inicialização
+     */
+    private static function reportInitIssue($message) {
+        error_log('SIMPLE_LOGGER_INIT: ' . $message);
     }
 }
 

--- a/test-logs.php
+++ b/test-logs.php
@@ -16,8 +16,11 @@ SimpleLogger::pix('TEST', 'Teste de PIX log');
 SimpleLogger::webhook('TEST', 'Teste de webhook log');
 
 // Verificar arquivos de log
-$logDir = 'logs/';
-$logFiles = glob($logDir . '*.log');
+$logDir = SimpleLogger::getLogDir();
+$logFiles = is_dir($logDir) ? glob($logDir . '*.log') : [];
+$logFiles = $logFiles ?: [];
+
+$appLogFile = $logDir . 'app_' . date('Y-m-d') . '.log';
 
 $response = [
     'success' => true,
@@ -26,13 +29,13 @@ $response = [
     'log_files' => $logFiles,
     'log_files_count' => count($logFiles),
     'current_date' => date('Y-m-d'),
-    'app_log_file' => $logDir . 'app_' . date('Y-m-d') . '.log',
-    'app_log_exists' => file_exists($logDir . 'app_' . date('Y-m-d') . '.log')
+    'app_log_file' => $appLogFile,
+    'app_log_exists' => file_exists($appLogFile)
 ];
 
 // Se o arquivo de log do dia existe, mostrar algumas linhas
-if (file_exists($logDir . 'app_' . date('Y-m-d') . '.log')) {
-    $lines = file($logDir . 'app_' . date('Y-m-d') . '.log', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+if (file_exists($appLogFile)) {
+    $lines = file($appLogFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
     $response['app_log_lines_count'] = count($lines);
     $response['app_log_last_5_lines'] = array_slice($lines, -5);
 }


### PR DESCRIPTION
## Summary
- update `SimpleLogger` to validate directory creation, fall back to a temp path when necessary, and expose the effective log directory
- update utility scripts and webhook tooling to consume the resolved log path so diagnostics continue to work when the default folder is unavailable
- align webhook logger configuration with the resolved log directory for consistent rotation and cleanup

## Testing
- php test-logs.php
- php -r '$_SERVER["REQUEST_METHOD"] = "GET"; $_GET["limit"] = 5; include "webhook-logs-api.php";'


------
https://chatgpt.com/codex/tasks/task_e_68cb8b8b4388832ab2f89055d88e3ca2